### PR TITLE
Moar tests

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -9,7 +9,7 @@ def main():
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'slowrun.settings')
     try:
         from django.core.management import execute_from_command_line
-    except ImportError as exc:
+    except ImportError as exc: # pragma: no cover
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "

--- a/slowrun/urls.py
+++ b/slowrun/urls.py
@@ -27,6 +27,6 @@ urlpatterns = [
     path("uutiset/<int:uutinen_id>/", uutiset_views.uutinen_detail, name="uutinen_detail")
 ]
 
-if settings.DEBUG:
+if settings.DEBUG: # pragma: no cover
     urlpatterns += static(settings.STATIC_URL, document_root=settings.BASE_DIR / "static")
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/uutiset/tests/test_views.py
+++ b/uutiset/tests/test_views.py
@@ -1,8 +1,0 @@
-'''from django.test import TestCase
-from django.urls import reverse
-
-class HomeViewTest(TestCase):
-    def test_home_redirects_to_static_index(self):
-        response = self.client.get(reverse("home"))
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "static/index.html")'''

--- a/uutiset/tests/test_views_models.py
+++ b/uutiset/tests/test_views_models.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from django.core.files.uploadedfile import SimpleUploadedFile
+from datetime import timedelta
+from uutiset.models import Uutinen
+from uutiset import views
+
+class UutisetTest(TestCase):
+    def setUp(self):
+        fake_image = SimpleUploadedFile(
+            name="test.jpg",
+            content=b"",
+            content_type="image/jpeg"
+        )
+        self.test_uutinen_0 = Uutinen.objects.create(id=1, title="testiotsikko", content="testikontentti", date=timezone.now(), picture=fake_image)
+        self.test_uutinen_1 = Uutinen.objects.create(picture=fake_image)
+        self.test_uutinen_2 = Uutinen.objects.create(picture=fake_image)
+
+    def test_uutinen_creation(self):
+        self.assertEqual(Uutinen.objects.count(), 3)
+
+    def test_uutinen_string(self):
+        self.assertEqual(self.test_uutinen_0.__str__(), "testiotsikko")
+
+    def test_uutiset_view(self):
+        response = self.client.get(reverse("uutiset"))
+        self.assertContains(response, "testiotsikko")
+
+    def test_uutiset_detail(self):
+        response = self.client.get(reverse("uutinen_detail", args=[self.test_uutinen_0.id]))
+        self.assertContains(response, "testiotsikko")


### PR DESCRIPTION
**Kuvaus**

- Kirjoitettu testit, jotka kattavat uutiset django-appin tiedostot. (models & views)
- Lisätty testauspakettia varten flagit, joiden avulla voidaan jättää tietyt koodin osat testikattavuuden ulkopuolelle.

**Trello kortti**
[Kattavat testit.](https://trello.com/c/OrafaQAX)