### PR TITLE
Kuvan poistuminen

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,4 +1,4 @@
-name: Sivun reitittimen testaus.
+name: Testien suoritus.
 
 on:
   pull_request:
@@ -20,4 +20,4 @@ jobs:
       - name: Suorita testit.
         run: |
           coverage run manage.py test
-          coverage report
+          coverage report --fail-under=80

--- a/uutiset/tests/test_views_models.py
+++ b/uutiset/tests/test_views_models.py
@@ -2,9 +2,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.core.files.uploadedfile import SimpleUploadedFile
-from datetime import timedelta
 from uutiset.models import Uutinen
-from uutiset import views
 import os, tempfile, shutil
 
 @override_settings(MEDIA_ROOT=tempfile.mkdtemp())

--- a/uutiset/tests/test_views_models.py
+++ b/uutiset/tests/test_views_models.py
@@ -1,11 +1,13 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.core.files.uploadedfile import SimpleUploadedFile
 from datetime import timedelta
 from uutiset.models import Uutinen
 from uutiset import views
+import os, tempfile, shutil
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class UutisetTest(TestCase):
     def setUp(self):
         fake_image = SimpleUploadedFile(
@@ -16,6 +18,9 @@ class UutisetTest(TestCase):
         self.test_uutinen_0 = Uutinen.objects.create(id=1, title="testiotsikko", content="testikontentti", date=timezone.now(), picture=fake_image)
         self.test_uutinen_1 = Uutinen.objects.create(picture=fake_image)
         self.test_uutinen_2 = Uutinen.objects.create(picture=fake_image)
+
+    def tearDown(self):
+        shutil.rmtree(self._overridden_settings["MEDIA_ROOT"])
 
     def test_uutinen_creation(self):
         self.assertEqual(Uutinen.objects.count(), 3)
@@ -30,3 +35,8 @@ class UutisetTest(TestCase):
     def test_uutiset_detail(self):
         response = self.client.get(reverse("uutinen_detail", args=[self.test_uutinen_0.id]))
         self.assertContains(response, "testiotsikko")
+
+    def test_picture_deletion(self):
+        for object in Uutinen.objects.all():
+            object.delete()
+        self.assertEqual(len(os.listdir(self._overridden_settings["MEDIA_ROOT"])), 0)

--- a/uutiset/views.py
+++ b/uutiset/views.py
@@ -14,5 +14,4 @@ def uutinen_detail(request, uutinen_id):
 @receiver(post_delete, sender=Uutinen)
 def delete_picture_on_uutinen_deletion(sender, instance, **kwargs):
     if instance.picture:
-        print(instance.picture)
         instance.picture.delete(save=False)

--- a/uutiset/views.py
+++ b/uutiset/views.py
@@ -1,4 +1,6 @@
 from django.shortcuts import render, get_object_or_404
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 from .models import Uutinen
 
 def uutiset_view(request):
@@ -8,3 +10,9 @@ def uutiset_view(request):
 def uutinen_detail(request, uutinen_id):
     uutinen = get_object_or_404(Uutinen, id=uutinen_id)
     return render(request, "uutinen_detail.html", {"uutinen": uutinen})
+
+@receiver(post_delete, sender=Uutinen)
+def delete_picture_on_uutinen_deletion(sender, instance, **kwargs):
+    if instance.picture:
+        print(instance.picture)
+        instance.picture.delete(save=False)


### PR DESCRIPTION
**Kuvaus**

- Lisätty Django-signaali, joka poistaa kuvatiedoston, kun uutinen-objekti poistetaan.
- Kirjoitettu testi signaalille ja korjattu testikuvien luomisen ongelma testejä suorittaessa.
- Muokattu workflow-tiedostoa sopivammaksi.

**Trello kortti**
[Kuvan poistuminen uutinen-objektin poistuessa.](https://trello.com/c/BSpoD2ZY)